### PR TITLE
Read CORS policy from JSON config files

### DIFF
--- a/src/API/Config/cors.Development.json
+++ b/src/API/Config/cors.Development.json
@@ -1,0 +1,8 @@
+{
+  "CorsPolicy": {
+    "Name": "Development",
+    "Headers": [ "*" ],
+    "Methods": [ "*" ],
+    "Origins": [ "*" ]
+  }
+}

--- a/src/API/Config/cors.Production.json
+++ b/src/API/Config/cors.Production.json
@@ -1,0 +1,7 @@
+{
+  "CorsPolicy": {
+    "Name": "Production",
+    "Methods": [ "GET", "POST" ],
+    "Origins": [ "http://example.com" ]
+  }
+}

--- a/src/API/Config/cors.json
+++ b/src/API/Config/cors.json
@@ -1,0 +1,7 @@
+{
+  "CorsPolicy": {
+    "Name": "Default",
+    "Methods": [ "GET", "POST" ],
+    "Origins": [ "http://localhost:3000" ]
+  }
+}

--- a/src/API/CorsPolicyOptions.cs
+++ b/src/API/CorsPolicyOptions.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.AspNetCore.Cors.Infrastructure;
+
+public class CorsPolicyOptions : CorsPolicy
+{
+    public string Name { get; set; }
+}

--- a/src/API/Program.cs
+++ b/src/API/Program.cs
@@ -27,15 +27,10 @@ builder.Services.AddControllers()
     .AddFluentValidation(_ => _.RegisterValidatorsFromAssemblyContaining<DummyValidator>());
 
 // Adding CORS policy
-const string DefaultCorsPolicy = "_myAllowSpecificOrigins";
+var corsPolicy = builder.Configuration.GetSection("CorsPolicy").Get<CorsPolicyOptions>();
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy(DefaultCorsPolicy, policy =>
-    {
-        policy.AllowAnyHeader()
-            .AllowAnyMethod()
-            .AllowAnyOrigin();
-    });
+    options.AddPolicy(corsPolicy.Name, corsPolicy);
 });
 
 // Disabling automatic model state validation of ASP.NET Core
@@ -102,7 +97,7 @@ app.UseApiLogging();
 
 app.MapControllers();
 
-app.UseCors(DefaultCorsPolicy);
+app.UseCors(corsPolicy.Name);
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
From now on we can write CORS policy configs in JSON files 😍

**How?**
We can have different json files for different environments (Development, Production, etc.) in the Config folder.
For example, I added cors.json, cors.Development.json and cors.Production.json.

```json
{
  "CorsPolicy": {
    "Name": "Default",
    "Methods": [ "GET", "POST" ],
    "Origins": [ "http://localhost:3000" ]
  }
}
```

```json
{
  "CorsPolicy": {
    "Name": "Development",
    "Headers": [ "*" ],
    "Methods": [ "*" ],
    "Origins": [ "*" ]
  }
}
```

```json
{
  "CorsPolicy": {
    "Name": "Production",
    "Methods": [ "GET", "POST" ],
    "Origins": [ "http://example.com" ]
  }
}
```
And I added this code to Startup.cs:
```cs
var corsPolicy = builder.Configuration.GetSection("CorsPolicy").Get<CorsPolicyOptions>();
builder.Services.AddCors(options =>
{
    options.AddPolicy(corsPolicy.Name, corsPolicy);
});

app.UseCors(corsPolicy.Name);
```